### PR TITLE
Moved to proper way for referencing host node for cross-docker scrapes.

### DIFF
--- a/creating-dashboards-with-grafana/step1.md
+++ b/creating-dashboards-with-grafana/step1.md
@@ -9,7 +9,7 @@ docker run -d --net=host \
 
 
 ```
-docker run -d -p 9100:9100 \
+docker run -d \
   -v "/proc:/host/proc" \
   -v "/sys:/host/sys" \
   -v "/:/rootfs" \

--- a/docker-metrics/step2.md
+++ b/docker-metrics/step2.md
@@ -15,7 +15,7 @@ scrape_configs:
   - job_name: 'prometheus'
 
     static_configs:
-      - targets: ['localhost:9090', 'localhost:9100', 'localhost:9323']
+      - targets: ['127.0.0.1:9090', '127.0.0.1:9100', '127.0.0.1:9323']
         labels:
           group: 'prometheus'
 </pre>

--- a/docker-metrics/step4.md
+++ b/docker-metrics/step4.md
@@ -5,7 +5,7 @@ The Docker Metrics endpoint will return information related to Docker. To collec
 Launch the Node Exporter container. By mounting the host /proc and /sys directory, the container has accessed to the necessary information to report on.
 
 ```
-docker run -d -p 9100:9100 \
+docker run -d \
   -v "/proc:/host/proc" \
   -v "/sys:/host/sys" \
   -v "/:/rootfs" \

--- a/getting-started/step1.md
+++ b/getting-started/step1.md
@@ -15,7 +15,7 @@ scrape_configs:
   - job_name: 'prometheus'
 
     static_configs:
-      - targets: ['localhost:9090', 'localhost:9100']
+      - targets: ['127.0.0.1:9090', '127.0.0.1:9100']
         labels:
           group: 'prometheus'
 </pre>

--- a/getting-started/step3.md
+++ b/getting-started/step3.md
@@ -5,7 +5,7 @@ To collect metrics related to a node it's required to run a Prometheus Node Expo
 Launch the Node Exporter container. By mounting the host /proc and /sys directory, the container has accessed to the necessary information to report on.
 
 ```
-docker run -d -p 9100:9100 \
+docker run -d \
   -v "/proc:/host/proc" \
   -v "/sys:/host/sys" \
   -v "/:/rootfs" \


### PR DESCRIPTION
Without this, two available courses are broken. I think it's because docker version upgrade,
and we are getting `Get http://localhost:9090/metrics: dial tcp: lookup localhost on 8.8.8.8:53: no such host` for each scrape.

127.0.0.1 seems like a current way.

Additionally exposing docker ports when running docker with --net=host produces warning.

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>

PTAL @juliusv  @BenHall 

Bonus question for overall Katacoda to @BenHall :
* Some reference to github repo with scenarios for each course in Katacoda website would be awesome. I needed to search for this in github to contribute and that was not that trivial.
* I reported feedback on page, but is it feedback for course or Katacoda itself? Maybe worth to separate those?

Anyway, it's really nice. Looking forward to adding more for Thanos.